### PR TITLE
feat: add auth roles and theme settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # ERP Gas — Firebase + React
 
+Proyecto de ejemplo con Firebase Auth (email y proveedores Google/Facebook), Firestore y Cloud Functions con Express. Incluye control de roles mediante *custom claims* y una interfaz React + Vite + TailwindCSS con tema claro/oscuro personalizable.
+
 ### Requisitos
 - Docker y Docker Compose instalados.
+- Node.js 20
 
 ### Pasos rápidos
 1) Clona o copia este repo y crea el archivo `.env` en la raíz (usa el ejemplo del proyecto).
@@ -40,16 +43,14 @@ firebase deploy --only hosting,functions
 La configuración de Firebase se encuentra en `firebase.json` y `.firebaserc`.
 
 ### Pruebas y CI
-Las pruebas unitarias se ejecutan con `pytest`:
+Ejecuta las pruebas de la web y las funciones:
 
 ```bash
-cd api
-pytest
+npm run test:web
+npm run test:functions
 ```
 
-Un flujo de trabajo de GitHub Actions (`.github/workflows/tests.yml`) ejecuta estas pruebas en cada *push* o *pull request*.
+Los flujos de trabajo de GitHub Actions (`.github/workflows/ci-cd.yaml`) realizan lint, pruebas, compilación y despliegue automático a Firebase al hacer push a `main`.
 
-El flujo `.github/workflows/ci-cd.yaml` realiza lint, pruebas, compilación y despliegue automático a Firebase al hacer push a `main`.
-
-### Logging
-La API utiliza logging estructurado basado en la configuración estándar de Python, controlado por la variable de entorno `LOG_LEVEL`.
+### API
+Los endpoints disponibles se describen en `/#/docs` una vez desplegado el sitio.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,20 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function hasRole(r) {
+      return isSignedIn() && request.auth.token.role == r;
+    }
+
+    match /products/{doc} {
+      allow read: if isSignedIn();
+      allow create, update, delete: if hasRole('ADMIN');
+    }
+
     match /{document=**} {
-      allow read, write: if false; // TODO: implement RBAC rules
+      allow read, write: if false;
     }
   }
 }

--- a/functions/src/routes/auth.ts
+++ b/functions/src/routes/auth.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import { getAuth } from 'firebase-admin/auth';
+import { verifyToken, requireRole } from '../auth';
+import { Role } from '../rbac';
 
 export const router = Router();
 
@@ -17,6 +19,41 @@ router.post('/register', async (req, res) => {
 router.post('/login', async (_req, res) => {
   // Auth handled on client via Firebase Auth SDK
   res.status(501).send('Use client SDK to login');
+});
+
+router.post('/assign-role', verifyToken, requireRole(['ADMIN']), async (req, res) => {
+  const { uid, role } = req.body as { uid?: string; role?: Role };
+  if (!uid || !role) return res.status(400).send('Missing fields');
+  if (!['ADMIN', 'OPERATOR', 'DISPATCH', 'CASH'].includes(role)) {
+    return res.status(400).send('Invalid role');
+  }
+  try {
+    await getAuth().setCustomUserClaims(uid, { role });
+    res.json({ uid, role });
+  } catch (e: any) {
+    res.status(500).send(e.message);
+  }
+});
+
+router.get('/profile', verifyToken, async (req, res) => {
+  const uid = (req as any).user.uid;
+  try {
+    const record = await getAuth().getUser(uid);
+    res.json({ uid: record.uid, email: record.email, role: (record.customClaims as any)?.role });
+  } catch (e: any) {
+    res.status(500).send(e.message);
+  }
+});
+
+router.post('/revoke', verifyToken, requireRole(['ADMIN']), async (req, res) => {
+  const { uid } = req.body as { uid?: string };
+  if (!uid) return res.status(400).send('Missing uid');
+  try {
+    await getAuth().revokeRefreshTokens(uid);
+    res.send('ok');
+  } catch (e: any) {
+    res.status(500).send(e.message);
+  }
 });
 
 export default router;

--- a/storage.rules
+++ b/storage.rules
@@ -2,7 +2,8 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if false; // TODO: implement RBAC rules
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.token.role == 'ADMIN';
     }
   }
 }

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,18 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open('static-v1').then((cache) =>
+      cache.match(event.request).then((res) => {
+        return (
+          res ||
+          fetch(event.request).then((response) => {
+            cache.put(event.request, response.clone());
+            return response;
+          })
+        );
+      })
+    )
+  );
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,25 @@
-import { useEffect, useState } from 'react'
-import Nav from './components/Nav'
-import Header from './components/Header'
-import Dashboard from './pages/Dashboard'
-import Inventory from './pages/Inventory'
-import Clients from './pages/Clients'
-import Prices from './pages/Prices'
-import Sales from './pages/Sales'
-import Purchases from './pages/Purchases'
-import Cashbox from './pages/Cashbox'
-import Settings from './pages/Settings'
-import { useUser, loginWithGoogle, logout } from './lib/auth'
+import { useEffect, useState, lazy, Suspense } from 'react';
+import Nav from './components/Nav';
+import Header from './components/Header';
+import {
+  useUser,
+  loginWithGoogle,
+  loginWithFacebook,
+  loginWithEmail,
+  registerWithEmail,
+  resetPassword,
+  logout,
+} from './lib/auth';
+
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Inventory = lazy(() => import('./pages/Inventory'));
+const Clients = lazy(() => import('./pages/Clients'));
+const Prices = lazy(() => import('./pages/Prices'));
+const Sales = lazy(() => import('./pages/Sales'));
+const Purchases = lazy(() => import('./pages/Purchases'));
+const Cashbox = lazy(() => import('./pages/Cashbox'));
+const Settings = lazy(() => import('./pages/Settings'));
+const Docs = lazy(() => import('./pages/Docs'));
 
 function useHashRoute() {
   const [route, setRoute] = useState(location.hash.slice(1) || '/')
@@ -24,15 +34,80 @@ function useHashRoute() {
 export default function App() {
   const route = useHashRoute()
   const user = useUser()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleRegister() {
+    setLoading(true); setError('')
+    try { await registerWithEmail(email, password); alert('Verifica tu correo') } catch (e:any) { setError(e.message) }
+    finally { setLoading(false) }
+  }
+
+  async function handleLogin() {
+    setLoading(true); setError('')
+    try { await loginWithEmail(email, password) } catch (e:any) { setError(e.message) }
+    finally { setLoading(false) }
+  }
+
+  async function handleReset() {
+    try { await resetPassword(email); alert('Email de recuperación enviado') } catch (e:any) { setError(e.message) }
+  }
   return (
     <div className="flex min-h-screen">
       <Nav />
       <main className="flex-1 p-6 bg-slate-50 dark:bg-slate-900">
         <Header />
         {!user && (
-          <button onClick={() => loginWithGoogle()} className="mb-4 rounded bg-blue-500 px-4 py-2 text-white">
-            Login with Google
-          </button>
+          <div className="mb-4 space-y-2 max-w-sm">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              className="w-full rounded border p-2"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className="w-full rounded border p-2"
+            />
+            {error && <div className="text-red-500 text-sm">{error}</div>}
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={handleRegister}
+                disabled={loading}
+                className="rounded bg-green-500 px-4 py-2 text-white"
+              >
+                Registro
+              </button>
+              <button
+                onClick={handleLogin}
+                disabled={loading}
+                className="rounded bg-blue-500 px-4 py-2 text-white"
+              >
+                Login
+              </button>
+              <button
+                onClick={() => loginWithGoogle()}
+                className="rounded bg-red-500 px-4 py-2 text-white"
+              >
+                Google
+              </button>
+              <button
+                onClick={() => loginWithFacebook()}
+                className="rounded bg-blue-700 px-4 py-2 text-white"
+              >
+                Facebook
+              </button>
+              <button onClick={handleReset} type="button" className="text-sm underline">
+                Recuperar contraseña
+              </button>
+            </div>
+          </div>
         )}
         {user && (
           <div className="mb-4 flex items-center gap-2">
@@ -40,14 +115,17 @@ export default function App() {
             <button onClick={() => logout()} className="rounded bg-red-500 px-2 py-1 text-white text-xs">Logout</button>
           </div>
         )}
-        {route === '/' && <Dashboard />}
-        {route === '/inventory' && <Inventory />}
-        {route === '/prices' && <Prices />}
-        {route === '/clients' && <Clients />}
-        {route === '/sales' && <Sales />}
-        {route === '/purchases' && <Purchases />}
-        {route === '/cash' && <Cashbox />}
-        {route === '/settings' && <Settings />}
+        <Suspense fallback={<div>Loading...</div>}>
+          {route === '/' && <Dashboard />}
+          {route === '/inventory' && <Inventory />}
+          {route === '/prices' && <Prices />}
+          {route === '/clients' && <Clients />}
+          {route === '/sales' && <Sales />}
+          {route === '/purchases' && <Purchases />}
+          {route === '/cash' && <Cashbox />}
+          {route === '/settings' && <Settings />}
+          {route === '/docs' && <Docs />}
+        </Suspense>
       </main>
     </div>
   )

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,13 +1,22 @@
-import React from 'react'
+import React from 'react';
+import { useUi } from '../lib/store';
 
 export default function Header() {
-  const toggleTheme = () => {
-    document.documentElement.classList.toggle('dark')
-  }
+  const { dark, setDark } = useUi();
   return (
-    <header className="mb-6 rounded-2xl bg-gradient-to-r from-brand.orange to-brand.orangeDark p-4 text-white flex items-center justify-between">
+    <header
+      role="banner"
+      className="mb-6 rounded-2xl p-4 text-white flex items-center justify-between bg-[var(--color-primary)]"
+      style={{ fontFamily: 'var(--font-family)' }}
+    >
       <h1 className="text-xl font-bold">ERP Gas</h1>
-      <button onClick={toggleTheme} className="rounded bg-white/20 px-3 py-1 text-sm hover:bg-white/30 transition">🌓</button>
+      <button
+        onClick={() => setDark(!dark)}
+        className="rounded bg-white/20 px-3 py-1 text-sm hover:bg-white/30 transition"
+        aria-label="Toggle theme"
+      >
+        🌓
+      </button>
     </header>
-  )
+  );
 }

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -14,6 +14,7 @@ export default function Nav() {
         <a href="#/purchases" className="hover:underline">Compras</a>
         <a href="#/cash" className="hover:underline">Caja</a>
         <a href="#/settings" className="hover:underline">Settings</a>
+        <a href="#/docs" className="hover:underline">Docs</a>
       </nav>
     </aside>
   )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,4 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: light dark; }
+:root {
+  color-scheme: light dark;
+  --color-primary: #FB923C;
+  --font-family: sans-serif;
+}
+body {
+  font-family: var(--font-family);
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,6 +1,15 @@
 import { useEffect, useState } from 'react';
 import { auth, googleProvider, facebookProvider } from './firebase';
-import { signInWithPopup, onAuthStateChanged, signOut, User } from 'firebase/auth';
+import {
+  signInWithPopup,
+  onAuthStateChanged,
+  signOut,
+  User,
+  createUserWithEmailAndPassword,
+  sendEmailVerification,
+  signInWithEmailAndPassword,
+  sendPasswordResetEmail,
+} from 'firebase/auth';
 
 export function useUser() {
   const [user, setUser] = useState<User | null>(null);
@@ -18,4 +27,18 @@ export function loginWithFacebook() {
 
 export function logout() {
   return signOut(auth);
+}
+
+export async function registerWithEmail(email: string, password: string) {
+  const cred = await createUserWithEmailAndPassword(auth, email, password);
+  await sendEmailVerification(cred.user);
+  return cred.user;
+}
+
+export function loginWithEmail(email: string, password: string) {
+  return signInWithEmailAndPassword(auth, email, password);
+}
+
+export function resetPassword(email: string) {
+  return sendPasswordResetEmail(auth, email);
 }

--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -1,11 +1,47 @@
 import create from 'zustand';
 
+const storageKey = 'ui';
+
 interface UiState {
   dark: boolean;
-  toggleDark: () => void;
+  primary: string;
+  font: string;
+  init: () => void;
+  setDark: (v: boolean) => void;
+  setPrimary: (c: string) => void;
+  setFont: (f: string) => void;
 }
 
-export const useUi = create<UiState>((set) => ({
+export const useUi = create<UiState>((set, get) => ({
   dark: false,
-  toggleDark: () => set((s) => ({ dark: !s.dark })),
+  primary: '#FB923C',
+  font: 'sans-serif',
+  init: () => {
+    const raw = localStorage.getItem(storageKey);
+    if (raw) {
+      const data = JSON.parse(raw);
+      set({ dark: data.dark ?? false, primary: data.primary || '#FB923C', font: data.font || 'sans-serif' });
+      document.documentElement.classList.toggle('dark', data.dark);
+      document.documentElement.style.setProperty('--color-primary', data.primary || '#FB923C');
+      document.documentElement.style.setProperty('--font-family', data.font || 'sans-serif');
+    } else {
+      document.documentElement.style.setProperty('--color-primary', '#FB923C');
+      document.documentElement.style.setProperty('--font-family', 'sans-serif');
+    }
+  },
+  setDark: (dark) => {
+    set({ dark });
+    localStorage.setItem(storageKey, JSON.stringify({ ...get(), dark }));
+    document.documentElement.classList.toggle('dark', dark);
+  },
+  setPrimary: (primary) => {
+    set({ primary });
+    localStorage.setItem(storageKey, JSON.stringify({ ...get(), primary }));
+    document.documentElement.style.setProperty('--color-primary', primary);
+  },
+  setFont: (font) => {
+    set({ font });
+    localStorage.setItem(storageKey, JSON.stringify({ ...get(), font }));
+    document.documentElement.style.setProperty('--font-family', font);
+  },
 }));

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,19 @@
-import React from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { useUi } from './lib/store';
+
+useUi.getState().init();
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(console.error);
+  });
+}
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -1,0 +1,13 @@
+export default function Docs() {
+  return (
+    <div className="space-y-2 text-sm">
+      <h2 className="text-xl font-bold mb-4">API Docs</h2>
+      <p>Endpoints disponibles:</p>
+      <ul className="list-disc pl-5 space-y-1">
+        <li><code>POST /api/auth/assign-role</code> — cuerpo: {'{ uid, role }'} — requiere rol ADMIN.</li>
+        <li><code>GET /api/auth/profile</code> — retorna perfil del usuario autenticado.</li>
+        <li><code>POST /api/auth/revoke</code> — cuerpo: {'{ uid }'} — revoca sesiones de un usuario (ADMIN).</li>
+      </ul>
+    </div>
+  );
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,3 +1,24 @@
+import { useUi } from '../lib/store';
+
 export default function Settings() {
-  return <div>Settings</div>;
+  const { dark, setDark, primary, setPrimary, font, setFont } = useUi();
+  return (
+    <div className="space-y-4 max-w-sm">
+      <div className="flex items-center gap-2">
+        <label htmlFor="dark">Dark mode</label>
+        <input id="dark" type="checkbox" checked={dark} onChange={e => setDark(e.target.checked)} />
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="color">Color primario</label>
+        <input id="color" type="color" value={primary} onChange={e => setPrimary(e.target.value)} />
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="font">Tipografía</label>
+        <select id="font" value={font} onChange={e => setFont(e.target.value)} className="border p-1">
+          <option value="sans-serif">Sans</option>
+          <option value="serif">Serif</option>
+        </select>
+      </div>
+    </div>
+  );
 }

--- a/web/tests/App.test.tsx
+++ b/web/tests/App.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { act } from 'react-dom/test-utils';
 jest.mock('../src/lib/firebase');
 import App from '../src/App';
 
-test('renders header', () => {
-  render(<App />);
+test('renders header', async () => {
+  await act(async () => {
+    render(<App />);
+  });
   expect(screen.getByRole('banner')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add role assignment, profile, and session revoke endpoints
- store theme preferences with color/font options and service worker caching
- document API routes and extend Firebase security rules

## Testing
- `npm run test:functions`
- `npm --prefix web test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6897b7804ac08322b17389ffe791eca4