### PR TITLE
Add persistent app configuration with import/export

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,8 @@
+import { useConfig } from './store';
+
 export async function api(path: string, options?: RequestInit) {
-  const res = await fetch(`/api${path}`, {
+  const base = useConfig.getState().apiBase || '';
+  const res = await fetch(`${base}${path}`, {
     headers: { 'Content-Type': 'application/json', ...(options?.headers || {}) },
     ...options,
   });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { useUi } from './lib/store';
+import { useUi, useConfig } from './lib/store';
 
 useUi.getState().init();
+useConfig.getState().init();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,7 +1,45 @@
-import { useUi } from '../lib/store';
+import { ChangeEvent } from 'react';
+import { useUi, useConfig } from '../lib/store';
 
 export default function Settings() {
   const { dark, setDark, primary, setPrimary, font, setFont } = useUi();
+  const { apiBase, setApiBase, company, setCompany, currency, setCurrency, load } = useConfig();
+
+  const exportConfig = () => {
+    const data = {
+      ui: { dark, primary, font },
+      config: { apiBase, company, currency },
+    };
+    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'config.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importConfig = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string);
+        if (data.ui) {
+          if (typeof data.ui.dark === 'boolean') setDark(data.ui.dark);
+          if (typeof data.ui.primary === 'string') setPrimary(data.ui.primary);
+          if (typeof data.ui.font === 'string') setFont(data.ui.font);
+        }
+        if (data.config) {
+          load(data.config);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    reader.readAsText(file);
+  };
   return (
     <div className="space-y-4 max-w-sm">
       <div className="flex items-center gap-2">
@@ -18,6 +56,22 @@ export default function Settings() {
           <option value="sans-serif">Sans</option>
           <option value="serif">Serif</option>
         </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="api">API base</label>
+        <input id="api" type="text" value={apiBase} onChange={e => setApiBase(e.target.value)} className="border p-1 flex-1" />
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="company">Empresa</label>
+        <input id="company" type="text" value={company} onChange={e => setCompany(e.target.value)} className="border p-1 flex-1" />
+      </div>
+      <div className="flex items-center gap-2">
+        <label htmlFor="currency">Moneda</label>
+        <input id="currency" type="text" value={currency} onChange={e => setCurrency(e.target.value)} className="border p-1 flex-1" />
+      </div>
+      <div className="flex items-center gap-2">
+        <button onClick={exportConfig} className="border p-1">Exportar</button>
+        <input type="file" accept="application/json" onChange={importConfig} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Zustand store to persist API base URL, company name, and currency
- extend settings page with fields for configuration plus import/export backup
- load stored config on startup and use it for API requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898007d5ce483229aecce4a34d7b496