### PR TITLE
feat: enable SQLite by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ Proyecto de ejemplo con Firebase Auth (email y proveedores Google/Facebook), Fir
 docker compose up --build
 ```
 
+### Base de datos
+
+La API usa **SQLite** por defecto, por lo que no se necesita un contenedor de
+base de datos adicional. El archivo se crea en `api/erp_gas.db` al ejecutar el
+comando anterior.
+
+Si prefieres **PostgreSQL**, levanta un servidor de Postgres y define la
+variable de entorno `DATABASE_URL` con la cadena de conexión, por ejemplo:
+
+```bash
+DATABASE_URL=postgresql+psycopg://erp_user:erp_pass@localhost:5432/erp_gas docker compose up --build
+```
+
+En este modo asegúrate de que el servicio de Postgres esté disponible y se
+puede agregar a `docker-compose.yml` si se desea manejarlo con Docker.
+
 ### Entorno local con Firebase
 1) Instala dependencias y crea tu `.env` basado en `.env.example`.
 2) Inicia la app web y funciones en modo desarrollo:

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -1,7 +1,10 @@
 from sqlmodel import SQLModel, create_engine, Session
 import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg://erp_user:erp_pass@db:5432/erp_gas")
+# Use SQLite by default for easier local development. If ``DATABASE_URL`` is
+# provided in the environment, it will override this value (for example to use
+# PostgreSQL in production).
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./erp_gas.db")
 connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
 engine = create_engine(DATABASE_URL, echo=False, connect_args=connect_args)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,9 @@
 version: '3.9'
 services:
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - "5432:5432"
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-
   api:
     build: ./api
-    depends_on:
-      db:
-        condition: service_healthy
     environment:
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: ${DATABASE_URL:-sqlite:///./erp_gas.db}
       API_KEY: ${API_KEY}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
     ports:
@@ -45,5 +26,4 @@ services:
       - api
 
 volumes:
-  pgdata:
   web_node_modules:     # <— volumen nombrado


### PR DESCRIPTION
## Summary
- default to sqlite for API database
- remove Postgres service from docker-compose and make DATABASE_URL optional
- document database modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68980c16946483228b45d01d75c2230d