### PR TITLE
Add startup scripts for building and running project

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+set MODE=%1
+if "%MODE%"=="" set MODE=server
+
+echo Installing Node dependencies...
+npm install || exit /b 1
+
+echo Building frontend...
+npm run build:web || exit /b 1
+
+echo Building backend functions...
+npm run build:functions || exit /b 1
+
+echo Installing Python dependencies...
+pip install -r api\requirements.txt || exit /b 1
+
+if "%MODE%"=="desktop" (
+  echo Starting desktop application...
+  npm --prefix desktop run start
+) else (
+  echo Starting API server...
+  python -m uvicorn api.app.main:app --host 0.0.0.0 --port 8000
+)

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+MODE=${1:-server}
+
+echo "Installing Node dependencies..."
+npm install
+
+echo "Building frontend..."
+npm run build:web
+
+echo "Building backend functions..."
+npm run build:functions
+
+echo "Installing Python dependencies..."
+pip install -r api/requirements.txt
+
+if [ "$MODE" = "desktop" ]; then
+  echo "Starting desktop application..."
+  npm --prefix desktop run start
+else
+  echo "Starting API server..."
+  python -m uvicorn api.app.main:app --host 0.0.0.0 --port 8000
+fi


### PR DESCRIPTION
## Summary
- add `start.sh` for Linux/macOS to install dependencies, build web and functions, and start API server or desktop app
- add `start.bat` for Windows with equivalent workflow

## Testing
- `./start.sh` (Ctrl+C after server start)
- `npm run test:web`
- `npm run test:functions`
- `pytest api`


------
https://chatgpt.com/codex/tasks/task_e_6898158a7a148322ab1c10ff03cdd629