### PR TITLE
feat: enhance dashboard and inventory ui

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2,16 +2,41 @@ import { useEffect, useState } from 'react'
 import { api } from '../lib/api'
 import Card from '../components/Card'
 
-export default function Dashboard(){
+export default function Dashboard() {
   const [data, setData] = useState<any>({})
+  const [recent, setRecent] = useState<any[]>([])
+
   useEffect(() => {
     api('/reports/summary').then(setData).catch(console.error)
+    api('/activity/recent').then(setRecent).catch(() => setRecent([]))
   }, [])
+
   return (
-    <div className="grid md:grid-cols-3 gap-4">
-      <Card title="Ventas (CLP)" value={data.total_ventas ?? 0} />
-      <Card title="Compras (CLP)" value={data.total_compras ?? 0} />
-      <Card title="Mov. Inventario" value={data.movimientos ?? 0} />
+    <div className="grid gap-6">
+      <div className="grid md:grid-cols-3 gap-4">
+        <Card title="Ventas (CLP)" value={data.total_ventas ?? 0} />
+        <Card title="Compras (CLP)" value={data.total_compras ?? 0} />
+        <Card title="Mov. Inventario" value={data.movimientos ?? 0} />
+      </div>
+
+      <section className="grid md:grid-cols-2 gap-4">
+        <div>
+          <h2 className="font-semibold mb-2">Reportes</h2>
+          <ul className="text-sm list-disc pl-5">
+            <li><a href="#/sales" className="text-blue-600 underline">Ventas</a></li>
+            <li><a href="#/purchases" className="text-blue-600 underline">Compras</a></li>
+          </ul>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Actividades recientes</h2>
+          <ul className="text-sm space-y-1">
+            {recent.length === 0 && <li>No hay actividades recientes</li>}
+            {recent.map((r, i) => (
+              <li key={i}>{r.descripcion || JSON.stringify(r)}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
     </div>
   )
 }

--- a/web/src/pages/Inventory.tsx
+++ b/web/src/pages/Inventory.tsx
@@ -1,32 +1,108 @@
 import { useEffect, useState } from 'react'
 import { api } from '../lib/api'
 
-export default function Inventory(){
+export default function Inventory() {
   const [products, setProducts] = useState<any[]>([])
   const [movs, setMovs] = useState<any[]>([])
+  const [tab, setTab] = useState<'productos' | 'categorias' | 'movimientos'>('productos')
+  const [query, setQuery] = useState('')
+
   useEffect(() => {
     api('/products/').then(setProducts)
     api('/inventory/movements').then(setMovs)
   }, [])
+
+  const filtered = products.filter(p =>
+    p.formato.toLowerCase().includes(query.toLowerCase()) ||
+    p.codigo.toLowerCase().includes(query.toLowerCase())
+  )
+
   return (
     <div className="grid gap-6">
-      <section>
-        <h2 className="font-semibold mb-2">Productos</h2>
-        <table className="w-full text-sm">
-          <thead><tr><th className="text-left">Formato</th><th>Código</th><th>Precio</th><th>Min</th></tr></thead>
-          <tbody>
-            {products.map(p => (
-              <tr key={p.id} className="border-b"><td>{p.formato}</td><td className="text-center">{p.codigo}</td><td className="text-right">{p.precio_lista}</td><td className="text-center">{p.stock_minimo}</td></tr>
+      <div className="flex gap-2 mb-4">
+        <button
+          onClick={() => setTab('productos')}
+          className={`px-3 py-1 rounded ${tab === 'productos' ? 'bg-brand.orange text-black' : 'bg-slate-200 dark:bg-slate-700'}`}
+        >
+          Productos
+        </button>
+        <button
+          onClick={() => setTab('categorias')}
+          className={`px-3 py-1 rounded ${tab === 'categorias' ? 'bg-brand.orange text-black' : 'bg-slate-200 dark:bg-slate-700'}`}
+        >
+          Categorías
+        </button>
+        <button
+          onClick={() => setTab('movimientos')}
+          className={`px-3 py-1 rounded ${tab === 'movimientos' ? 'bg-brand.orange text-black' : 'bg-slate-200 dark:bg-slate-700'}`}
+        >
+          Movimientos
+        </button>
+      </div>
+
+      {tab === 'productos' && (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <input
+              className="border p-2 flex-1 mr-2"
+              placeholder="Buscar producto"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+            />
+            <button className="bg-brand.orange text-black font-semibold px-4 py-2 rounded">Agregar</button>
+          </div>
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left">Foto</th>
+                <th className="text-left">Formato</th>
+                <th>Código</th>
+                <th>Precio</th>
+                <th>Estado</th>
+                <th>Min</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(p => (
+                <tr key={p.id} className="border-b">
+                  <td className="py-1"><img src={p.foto || 'https://via.placeholder.com/40'} alt="foto" className="w-10 h-10 object-cover" /></td>
+                  <td>{p.formato}</td>
+                  <td className="text-center">{p.codigo}</td>
+                  <td className="text-right">{p.precio_lista}</td>
+                  <td className="text-center">{p.activo ? 'Activo' : 'Inactivo'}</td>
+                  <td className="text-center">{p.stock_minimo}</td>
+                  <td className="text-center">
+                    <div className="flex justify-center gap-2">
+                      <button className="text-blue-600 text-xs">Editar</button>
+                      <button className="text-red-600 text-xs">Eliminar</button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {tab === 'categorias' && (
+        <section className="text-sm">
+          <p>Gestión de categorías de productos próximamente.</p>
+        </section>
+      )}
+
+      {tab === 'movimientos' && (
+        <section>
+          <h2 className="font-semibold mb-2">Movimientos recientes</h2>
+          <ul className="text-sm">
+            {movs.map((m, i) => (
+              <li key={i}>
+                {m.fecha} — {m.tipo} x{m.cantidad} (prod {m.producto_id}) — {m.motivo}
+              </li>
             ))}
-          </tbody>
-        </table>
-      </section>
-      <section>
-        <h2 className="font-semibold mb-2">Movimientos recientes</h2>
-        <ul className="text-sm">
-          {movs.map((m,i) => <li key={i}>{m.fecha} — {m.tipo} x{m.cantidad} (prod {m.producto_id}) — {m.motivo}</li>)}
-        </ul>
-      </section>
+          </ul>
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expand dashboard with report links and recent activity
- redesign inventory with tabs, search and action buttons

## Testing
- `npm test`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898330158108322a5a798c6f5663914