### PR TITLE
fix: configure vitest and update tests

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,2 +1,5 @@
 import 'whatwg-fetch';
-import '@testing-library/jest-dom';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { expect } from 'vitest';
+
+expect.extend(matchers);

--- a/web/tests/App.test.tsx
+++ b/web/tests/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { act } from 'react-dom/test-utils';
-jest.mock('../src/lib/firebase');
+import { vi, test, expect } from 'vitest';
+vi.mock('../src/lib/firebase');
 import App from '../src/App';
 
 test('renders header', async () => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   server: { host: true },
   test: {
     environment: 'jsdom',
-    setupFiles: './src/test/setup.ts'
+    setupFiles: './src/test/setup.ts',
+    exclude: ['node_modules/**', 'dist/**', 'tests/smoke.spec.ts']
   }
 })


### PR DESCRIPTION
## Summary
- hook up Vitest with testing-library matchers
- migrate App.test to Vitest mocks
- exclude Playwright spec from unit tests

## Testing
- `pnpm --filter ./web test --run`
- `pnpm test:functions`
- `pnpm test:e2e` *(fails: Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_689c085621908322b139bad6fd0c3a1d